### PR TITLE
feat: 사용자, 게시물과 북마크 양방향 연결 추가

### DIFF
--- a/src/main/java/com/kwhackathon/broom/board/entity/Board.java
+++ b/src/main/java/com/kwhackathon/broom/board/entity/Board.java
@@ -1,5 +1,6 @@
 package com.kwhackathon.broom.board.entity;
 
+import java.util.List;
 import java.util.UUID;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -10,8 +11,10 @@ import org.hibernate.annotations.CreationTimestamp;
 
 import com.kwhackathon.broom.board.dto.BoardRequest.WriteBoardDto;
 import com.kwhackathon.broom.board.util.category.Category;
+import com.kwhackathon.broom.bookmark.entity.Bookmark;
 import com.kwhackathon.broom.user.entity.User;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -20,6 +23,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -71,6 +75,9 @@ public class Board {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+
+    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+    private List<Bookmark> bookmarks;
 
     public void updateBoard(WriteBoardDto writeBoardDto) {
         this.title = writeBoardDto.getTitle();

--- a/src/main/java/com/kwhackathon/broom/board/repository/BoardRepository.java
+++ b/src/main/java/com/kwhackathon/broom/board/repository/BoardRepository.java
@@ -3,9 +3,12 @@ package com.kwhackathon.broom.board.repository;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.kwhackathon.broom.board.entity.Board;
 import com.kwhackathon.broom.board.util.category.Category;
+import com.kwhackathon.broom.user.entity.User;
 
 import java.time.LocalDate;
 
@@ -24,4 +27,9 @@ public interface BoardRepository extends JpaRepository<Board, String> {
 
     // 인원 모집이 진행 중인 게시글만 조회
     Slice<Board> findSliceByCategoryAndIsFull(Pageable pageable, Category category, Boolean isFull);
+
+    Slice<Board> findSliceByBookmarksUser(Pageable pageable, User user);
+
+    @Query("SELECT b FROM Board b JOIN b.bookmarks bm WHERE bm.user.userId = :userId")
+    Slice<Board> findSliceByBookmarksUserUserId(Pageable pageable, @Param("userId")String userId);
 }

--- a/src/main/java/com/kwhackathon/broom/user/entity/User.java
+++ b/src/main/java/com/kwhackathon/broom/user/entity/User.java
@@ -8,8 +8,8 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
-import com.kwhackathon.broom.carpool.entity.CarpoolBoard;
-import com.kwhackathon.broom.team.entity.TeamBoard;
+import com.kwhackathon.broom.board.entity.Board;
+import com.kwhackathon.broom.bookmark.entity.Bookmark;
 import com.kwhackathon.broom.user.dto.request.UpdateUserInfoDto;
 import com.kwhackathon.broom.user.util.MilitaryChaplain;
 import com.kwhackathon.broom.user.util.Role;
@@ -55,10 +55,10 @@ public class User implements UserDetails {
     private Role role; // 권한 정보
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
-    private List<CarpoolBoard> carpoolBoards;
+    private List<Board> boards;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
-    private List<TeamBoard> teamBoards;
+    private List<Bookmark> bookmarks;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {


### PR DESCRIPTION
사용자, 게시물과 북마크 양방향 연결 추가:
- 사용자 엔티티에 북마크 필드 추가
- 게시물 엔티티에 북마크 필드 추가
- 게시물 repository에 사용자 정보를 이용한 북마크된 게시물 조회 메서드 추가
- 북마크로 등록된 게시물 조회 메서드 수정